### PR TITLE
Download Monitor admin simplification

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * General WordPress admin-related logic
+ */
+namespace FinAid\Utils\Admin;
+

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * General WordPress admin-related logic
- */
-namespace FinAid\Utils\Admin;
-

--- a/admin/downloads.php
+++ b/admin/downloads.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Functions that customize the admin interface for Downloads
+ * (via the Download Monitor plugin)
+ */
+namespace FinAid\Utils\Admin\Downloads;
+
+
+/**
+ * Removes unused columns from the Downloads list admin view.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @param array $columns Existing column definitions
+ * @return array Modified columns array
+ */
+function disable_columns( $columns ) {
+	$remove_keys = array(
+		'featured',
+		'members_only',
+		'redirect_only'
+	);
+	foreach ( $remove_keys as $key ) {
+		if ( isset( $columns[$key] ) ) {
+			unset( $columns[$key] );
+		}
+	}
+	return $columns;
+}
+
+add_filter( 'manage_edit-dlm_download_columns', __NAMESPACE__ . '\disable_columns', 11, 1 );

--- a/admin/downloads.php
+++ b/admin/downloads.php
@@ -7,14 +7,36 @@ namespace FinAid\Utils\Admin\Downloads;
 
 
 /**
- * Removes unused columns from the Downloads list admin view.
+ * Modifies the download CPT's registered supported features.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @param array $supports Existing array of supported features for the post type
+ * @return array Modified array of supported features
+ */
+function downloads_cpt_supports( $supports ) {
+	foreach ( $supports as $key => $val ) {
+		// Remove the post editor from single downloads
+		if ( $val === 'editor' ) {
+			unset( $supports[$key] );
+		}
+	}
+	return $supports;
+}
+
+add_filter( 'dlm_cpt_dlm_download_supports', __NAMESPACE__ . '\downloads_cpt_supports', 11, 1 );
+
+
+/**
+ * Modifies columns in the Downloads list admin view.
  *
  * @since 1.0.0
  * @author Jo Dickson
  * @param array $columns Existing column definitions
  * @return array Modified columns array
  */
-function disable_columns( $columns ) {
+function downloads_columns( $columns ) {
+	// Remove unused columns from the Downloads list admin view:
 	$remove_keys = array(
 		'featured',
 		'members_only',
@@ -28,27 +50,38 @@ function disable_columns( $columns ) {
 	return $columns;
 }
 
-add_filter( 'manage_edit-dlm_download_columns', __NAMESPACE__ . '\disable_columns', 11, 1 );
+add_filter( 'manage_edit-dlm_download_columns', __NAMESPACE__ . '\downloads_columns', 11, 1 );
 
 
 /**
- * TODO
+ * Modifies metaboxes registered for single downloads
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @return void
  */
-function disable_download_options_metabox() {
+function downloads_metaboxes() {
+	// Remove the "Download Options" metabox on single downloads
 	remove_meta_box( 'download-monitor-options', 'dlm_download', 'side' );
 }
 
-add_action( 'do_meta_boxes', __NAMESPACE__ . '\disable_download_options_metabox' );
+add_action( 'do_meta_boxes', __NAMESPACE__ . '\downloads_metaboxes' );
 
 
 /**
- * Remove "Browse for file" button under Download version add fields
+ * Modifies available upload buttons for single file versions.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @param array $upload_buttons Available upload button names
+ * @return array Modified upload button names
  */
-function disable_browse_for_file( $upload_buttons ) {
+function downloads_file_version_buttons( $upload_buttons ) {
+	// Remove "Browse for file" button under Download version add fields
 	if ( isset( $upload_buttons['browse_for_file'] ) ) {
 		unset( $upload_buttons['browse_for_file'] );
 	}
 	return $upload_buttons;
 }
 
-add_filter( 'dlm_downloadable_file_version_buttons', __NAMESPACE__ . '\disable_browse_for_file' );
+add_filter( 'dlm_downloadable_file_version_buttons', __NAMESPACE__ . '\downloads_file_version_buttons' );

--- a/admin/downloads.php
+++ b/admin/downloads.php
@@ -29,3 +29,26 @@ function disable_columns( $columns ) {
 }
 
 add_filter( 'manage_edit-dlm_download_columns', __NAMESPACE__ . '\disable_columns', 11, 1 );
+
+
+/**
+ * TODO
+ */
+function disable_download_options_metabox() {
+	remove_meta_box( 'download-monitor-options', 'dlm_download', 'side' );
+}
+
+add_action( 'do_meta_boxes', __NAMESPACE__ . '\disable_download_options_metabox' );
+
+
+/**
+ * Remove "Browse for file" button under Download version add fields
+ */
+function disable_browse_for_file( $upload_buttons ) {
+	if ( isset( $upload_buttons['browse_for_file'] ) ) {
+		unset( $upload_buttons['browse_for_file'] );
+	}
+	return $upload_buttons;
+}
+
+add_filter( 'dlm_downloadable_file_version_buttons', __NAMESPACE__ . '\disable_browse_for_file' );

--- a/finaid-utilities.php
+++ b/finaid-utilities.php
@@ -20,9 +20,6 @@ define( 'FINAID_UTILS__STATIC_URL', FINAID_UTILS__PLUGIN_URL . '/static' );
 define( 'FINAID_UTILS__JS_URL', FINAID_UTILS__STATIC_URL . '/js' );
 
 
-// Admin files
-require_once FINAID_UTILS__PLUGIN_PATH . 'admin/admin.php';
-
 // Includes
 require_once FINAID_UTILS__PLUGIN_PATH . 'plugin-filters/finaid-post-list-layout.php';
 

--- a/finaid-utilities.php
+++ b/finaid-utilities.php
@@ -7,7 +7,31 @@ Author: UCF Web Communications
 License: GPL3
 GitHub Plugin URI: UCF/FinAid-Utilities
 */
+namespace FinAid\Utils;
 
 if ( ! defined( 'WPINC' ) ) {
     die;
 }
+
+define( 'FINAID_UTILS__PLUGIN_FILE', __FILE__ );
+define( 'FINAID_UTILS__PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
+define( 'FINAID_UTILS__PLUGIN_URL', plugins_url( basename( dirname( __FILE__ ) ) ) );
+define( 'FINAID_UTILS__STATIC_URL', FINAID_UTILS__PLUGIN_URL . '/static' );
+define( 'FINAID_UTILS__JS_URL', FINAID_UTILS__STATIC_URL . '/js' );
+
+
+// Admin files
+require_once FINAID_UTILS__PLUGIN_PATH . 'admin/admin.php';
+
+// Includes
+// ...
+
+// Plugin-dependent files
+add_action( 'plugins_loaded', function() {
+
+	// Download monitor
+	if ( defined( 'DLM_PLUGIN_FILE' ) ) {
+		require_once FINAID_UTILS__PLUGIN_PATH . 'admin/downloads.php';
+	}
+
+} );


### PR DESCRIPTION
<!---
Thank you for contributing to FinAid-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/FinAid-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds overrides to the admin list view and edit view for single downloads:
- Removed post content WYSIWYG editor from single downloads
- Removed "Download Options" metabox from single downloads
- Removed per-version "Browse for file" button
- Removed admin list columns for sorting by featured, members only, and redirect only files

Before:
![Screen Shot 2019-09-27 at 12 44 38](https://user-images.githubusercontent.com/1649216/65913692-53b1a600-e39e-11e9-9c5c-08bf20f322e8.png)

After:
![Screen Shot 2019-09-27 at 12 44 17](https://user-images.githubusercontent.com/1649216/65913710-59a78700-e39e-11e9-8c72-f6ab55672327.png)

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make it easier for content managers to effectively manage downloadable files.  The folks managing the FinAid site won't need the features disabled in this PR, such as 'featured' downloads, browsing for files on the file system, etc.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
